### PR TITLE
Fix `recommended` config export to support flat config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-dist
-node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*.tsbuildinfo

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+// js
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
@@ -6,40 +7,39 @@ import eslintPlugin from "eslint-plugin-eslint-plugin";
 import nodePlugin from "eslint-plugin-n";
 import parser from "@typescript-eslint/parser";
 
-// This config follows suggestions from official ESLint custom plugin docs
-// https://eslint.org/docs/latest/extend/plugins#linting-a-plugin
 export default defineConfig([
+    // 1. Ignore build and dependency output everywhere
     {
-        files: ["**/*.js", "**/*.mjs", "**/*.ts"],
+        ignores: ["dist/", "node_modules/"],
+    },
+    // 2. TypeScript source files
+    {
+        files: ["src/**/*.{js,mjs,cjs,ts}"],
         languageOptions: {
             parser,
             ecmaVersion: 2024,
+            globals: globals.browser,
         },
-    },
-    // @eslint/js
-    {
-        plugins: { js },
-        extends: ["js/recommended"],
-    },
-    // eslint-plugin-eslint-plugin
-    eslintPlugin.configs["flat/recommended"],
-    {
+        plugins: {
+            js,
+            "eslint-plugin": eslintPlugin,
+            "n": nodePlugin,
+        },
+        extends: [
+            "js/recommended",
+            // node plugin's recommended config for scripts
+            nodePlugin.configs["flat/recommended-script"],
+            // typescript-eslint recommended
+            ...tseslint.configs.recommended,
+            // eslint-plugin-eslint-plugin recommended
+            eslintPlugin.configs["flat/recommended"],
+        ],
         rules: {
+            // Custom rules and overrides
             "eslint-plugin/require-meta-docs-description": "error",
-        },
-    },
-    // eslint-plugin-n
-    nodePlugin.configs["flat/recommended-script"],
-    {
-        rules: {
             "n/exports-style": ["error", "module.exports"],
             "n/no-missing-import": "off",
             "n/no-unpublished-import": "off",
         },
     },
-    {
-        files: ["src/**/*.{js,mjs,cjs,ts}"],
-        languageOptions: { globals: globals.browser },
-    },
-    tseslint.configs.recommended,
 ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "scripts": {
         "test": "vitest --run",
         "lint": "eslint .",
-        "build": "tsc --build tsconfig.build.json",
-        "publish": "npm publish --access public"
+        "build": "tsc --build tsconfig.build.json"
     },
     "files": [
         "dist"

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,3 +1,0 @@
-import { recommended } from "./recommended";
-
-export default { recommended };

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,6 +1,0 @@
-export const recommended = {
-    plugins: ["error-cause"],
-    rules: {
-        "error-cause/no-swallowed-error-cause": "error",
-    },
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,26 @@
-import configs from "./configs";
 import packageJson from "../package.json";
 import rules from "./rules";
+
 const meta = { name: packageJson.name, version: packageJson.version };
 
 const plugin = {
     meta,
-    configs,
+    configs: {},
     rules,
     processors: {},
 };
 
-export default plugin;
+Object.assign(plugin.configs, {
+    recommended: [
+        {
+            plugins: {
+                "error-cause": plugin,
+            },
+            rules: {
+                "error-cause/no-swallowed-error-cause": "warn",
+            },
+        },
+    ],
+});
+
+module.exports = plugin;


### PR DESCRIPTION
This fixes the `recommended` config export based on [Fix recommended config export to support flat config](https://github.com/Amnish04/eslint-plugin-error-cause/commit/5727c59bbfb831806bcd95ae9bda0ce3f6dd7789), and users can configure  this plugin in the following ways:

**eslint.config.mjs:**
```ts
import errorCause from "eslint-plugin-error-cause";
import { defineConfig } from "eslint/config";

// 1. Using the `recommended` config that comes in-built with the plugin
export default defineConfig([
    errorCause.configs.recommended,
]);

// 2. Configure the `no-swallowed-error-cause` with custom error level
export default defineConfig([
    {
    plugins: {
        "error-cause": errorCause,
    },
    rules: {
        "error-cause/no-swallowed-error-cause": "error",
    },
]);
```