### PR TITLE
Include docs folder in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {
@@ -13,7 +13,8 @@
         "update:eslint-docs": "eslint-doc-generator --init-rule-docs"
     },
     "files": [
-        "dist"
+        "dist",
+        "docs"
     ],
     "keywords": [
         "eslint",


### PR DESCRIPTION
I wasn't including the `docs` directory in files that are published to `npm` leading to broken link references like the following
<img width="1664" alt="image" src="https://github.com/user-attachments/assets/e86de2ff-51f6-4f8d-a211-06bb532cee71" />

This fixes the problem by including docs in `files` in the `package.json`

```
"files": [
        "dist",
        "docs"
  ],
```