### PR TITLE
Make `no-swallowed-error-cause` rule fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ export default defineConfig([
 
 <!-- begin auto-generated rules list -->
 
-| Name                                                               | Description                                                           |
-| :----------------------------------------------------------------- | :-------------------------------------------------------------------- |
-| [no-swallowed-error-cause](docs/rules/no-swallowed-error-cause.md) | disallow losing original error `cause` when rethrowing custom errors. |
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
+
+| Name                                                               | Description                                                           | 🔧 |
+| :----------------------------------------------------------------- | :-------------------------------------------------------------------- | :- |
+| [no-swallowed-error-cause](docs/rules/no-swallowed-error-cause.md) | disallow losing original error `cause` when rethrowing custom errors. | 🔧 |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/no-swallowed-error-cause.md
+++ b/docs/rules/no-swallowed-error-cause.md
@@ -1,4 +1,6 @@
-# Disallow losing original error `cause` when re-throwing custom errors (`error-cause/no-swallowed-error-cause`)
+# Disallow losing original error `cause` when rethrowing custom errors (`error-cause/no-swallowed-error-cause`)
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.0.7",
+    "version": "1.1.0",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "lint:docs": "markdownlint \"**/*.md\"",
         "lint:eslint-docs": "npm run update:eslint-docs -- --check",
         "lint:js": "eslint .",
-        "update:eslint-docs": "eslint-doc-generator --init-rule-docs"
+        "update:eslint-docs": "eslint-doc-generator"
     },
     "files": [
         "dist",

--- a/tests/swallowed-error-context.test.ts
+++ b/tests/swallowed-error-context.test.ts
@@ -94,6 +94,13 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
             }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+            try {
+            doSomething();
+            } catch (err) {
+            throw new Error("Something failed", { cause: err });
+            }
+            `,
         },
         // 2. Throws a new Error with unrelated cause
         {
@@ -106,6 +113,14 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
             }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+            try {
+            doSomething();
+            } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { cause: err });
+            }
+            `,
         },
         // 3. Throws a new Error with cause property, but value is not the caught error
         {
@@ -117,6 +132,13 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
                 }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                doSomething();
+                } catch (error) {
+                throw new Error("Failed", { cause: error });
+                }
+            `,
         },
         // 4. Throws a new Error, cause property is present but misspelled
         {
@@ -128,8 +150,16 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
                 }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                doSomething();
+                } catch (error) {
+                throw new Error("Failed", { cause: error });
+                }
+            `,
         },
         // 5. Throws a new Error, cause property is present but value is a different identifier
+        // TODO: We need to start allowing this behavior as it is not actually invalid.
         {
             code: `
                 try {
@@ -140,6 +170,14 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
                 }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                doSomething();
+                } catch (err) {
+                const e = err;
+                throw new Error("Failed", { cause: err });
+                }
+            `,
         },
         // 6. Throws a new Error, cause property is present but value is a member expression
         {
@@ -151,6 +189,13 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
                 }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                doSomething();
+                } catch (error) {
+                throw new Error("Failed", { cause: error });
+                }
+            `,
         },
         // 7. Throws a new Error, cause property is present but value is a literal
         {
@@ -162,6 +207,13 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
                 }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                doSomething();
+                } catch (error) {
+                throw new Error("Failed", { cause: error });
+                }
+            `,
         },
         // 8. Throws a new Error, cause property is present but value is a function call
         {
@@ -173,6 +225,13 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
                 }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                doSomething();
+                } catch (error) {
+                throw new Error("Failed", { cause: error });
+                }
+            `,
         },
         // 9. throw in a heavily nested catch block
         {
@@ -190,6 +249,19 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
               }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+              try {
+                doSomething();
+              } catch (error) {
+                if (shouldThrow) {
+                  while (true) {
+                    if (Math.random() > 0.5) {
+                      throw new Error("Failed without cause", { cause: error });
+                    }
+                  }
+                }
+              }
+            `,
         },
         // 10. construct with a `switch` statement
         {
@@ -208,6 +280,20 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
               }
             `,
             errors: [{ messageId: "missing-cause" }],
+            output: `
+              try {
+                doSomething();
+              } catch (error) {
+                switch (error.code) {
+                  case "A":
+                    throw new Error("Type A", { cause: error });
+                  case "B":
+                    throw new Error("Type B", { cause: error });
+                  default:
+                    throw new Error("Other", { cause: error });
+                }
+              }
+            `,
         },
     ],
 });


### PR DESCRIPTION
In its current state, the `no-swallowed-error-cause` works well to report instances of swallowed error `cause`, but it cannot automatically fix the problem.

This PR extends the rule to be `fixable` for both the following scenarios:
1. `cause` is not specified.
2. `cause` does not hold the actual root error.

Also updated the **invalid** test cases to also check the fixed output.

Updated the documentation as well!