### PR TITLE
Do not include `docs` in the published artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {
@@ -13,8 +13,7 @@
         "update:eslint-docs": "eslint-doc-generator"
     },
     "files": [
-        "dist",
-        "docs"
+        "dist"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
Docs do not need to be included in the published artifacts on npm, and they add an extra `713` bytes.