### PR TITLE
Fix edge cases in fixer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ An ESLint plugin with rules to report loss of original [error cause](https://nod
 
 ![code-art](https://github.com/user-attachments/assets/d4a68b8d-897b-4df9-a605-f24850d5759d)
 
-
 ## Table of Contents
 
-- [Background](#background)
-- [Installation](#installation)
-- [Configuration](#configuration-eslint-v8230-flat-config)
-- [License](#license)
-
+-   [Background](#background)
+-   [Installation](#installation)
+-   [Configuration](#configuration-eslint-v8230-flat-config)
+-   [License](#license)
 
 ## Background
 
@@ -95,9 +93,9 @@ export default defineConfig([
 
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                               | Description                                                           | 🔧 |
-| :----------------------------------------------------------------- | :-------------------------------------------------------------------- | :- |
-| [no-swallowed-error-cause](docs/rules/no-swallowed-error-cause.md) | disallow losing original error `cause` when rethrowing custom errors. | 🔧 |
+| Name                                                               | Description                                                           | 🔧  |
+| :----------------------------------------------------------------- | :-------------------------------------------------------------------- | :-- |
+| [no-swallowed-error-cause](docs/rules/no-swallowed-error-cause.md) | disallow losing original error `cause` when rethrowing custom errors. | 🔧  |
 
 <!-- end auto-generated rules list -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {

--- a/src/rules/no-swallowed-error-cause.ts
+++ b/src/rules/no-swallowed-error-cause.ts
@@ -41,12 +41,14 @@ export const noSwallowedErrorCause = createRule<Options, MessageIds>({
                             messageId: "missing-cause",
                             node: customThrow,
                             fix: (fixer) => {
+                                const newExpression = customThrow.argument;
+                                const messageArgument = newExpression.arguments[0];
                                 const errorMessage =
-                                    extractErrorMessageFromThrowStatemt(customThrow);
+                                    context.sourceCode.getText(messageArgument);
 
                                 return fixer.replaceText(
                                     customThrow,
-                                    `throw new Error("${errorMessage}", { cause: ${rootError.name} });`
+                                    `throw new Error(${errorMessage}, { cause: ${rootError.name} });`
                                 );
                             },
                         });
@@ -174,13 +176,4 @@ function findThrowNewErrorCause(throwStatement: ThrowNewErrorStatement) {
             : undefined;
 
     return causeProperty?.value;
-}
-
-function extractErrorMessageFromThrowStatemt(statement: ThrowNewErrorStatement) {
-    const newExpression = statement.argument;
-    const messageArgument = newExpression.arguments[0];
-
-    return messageArgument?.type === TSESTree.AST_NODE_TYPES.Literal
-        ? messageArgument.value
-        : undefined;
 }

--- a/tests/swallowed-error-context.test.ts
+++ b/tests/swallowed-error-context.test.ts
@@ -295,5 +295,43 @@ ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
               }
             `,
         },
+        // Throw statement with a template literal error message
+        {
+            code: `
+                try {
+                    doSomething();
+                } catch (error) {
+                    throw new Error(\`The certificate key "\${chalk.yellow(keyFile)}" is invalid.\n\${err.message}\`);
+                }
+            `,
+            errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                    doSomething();
+                } catch (error) {
+                    throw new Error(\`The certificate key "\${chalk.yellow(keyFile)}" is invalid.\n\${err.message}\`, { cause: error });
+                }
+            `,
+        },
+        // Throw statement with a variable error message
+        {
+            code: `
+                try {
+                    doSomething();
+                } catch (error) {
+                    const errorMessage = "Operation failed";
+                    throw new Error(errorMessage);
+                }
+            `,
+            errors: [{ messageId: "missing-cause" }],
+            output: `
+                try {
+                    doSomething();
+                } catch (error) {
+                    const errorMessage = "Operation failed";
+                    throw new Error(errorMessage, { cause: error });
+                }
+            `,
+        },
     ],
 });


### PR DESCRIPTION
An early user from reditt [reported](https://www.reddit.com/r/javascript/comments/1kta0ni/comment/mts3qpi/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) a bizarre bug where the `fixer` would replace the original error message with `undefined` when the error message was not a raw string literal like in the following test case I added.

```ts
// Throw statement with a template literal error message
{
    code: `
        try {
            doSomething();
        } catch (error) {
            throw new Error(\`The certificate key "\${chalk.yellow(keyFile)}" is invalid.\n\${err.message}\`);
        }
    `,
    errors: [{ messageId: "missing-cause" }],
    output: `
        try {
            doSomething();
        } catch (error) {
            throw new Error(\`The certificate key "\${chalk.yellow(keyFile)}" is invalid.\n\${err.message}\`, { cause: error });
        }
    `,
},
```

This was happening because was trying to manually extract error message from a `ThrowStatement` without handling all the edge-cases properly (e.g. the message argument could be `TemplateLiteral`, `Identifier` etc.)

I found that the most robust way to get the source code of a given node is using the [getText](https://eslint.org/docs/latest/extend/custom-rules#accessing-the-source-text) method on the `RuleContext` like so:

```ts
context.sourceCode.getText(messageArgument)
```

This handles it for all the edge-cases and passes with my newly [added test cases](https://github.com/Amnish04/eslint-plugin-error-cause/blob/018461129025225445fa4c003de21cbb435fb77b/tests/swallowed-error-context.test.ts#L298-L335) fixing #12.

<img width="923" alt="test cases passed" src="https://github.com/user-attachments/assets/8102a6de-a8ff-4fa9-ad4a-3436f1be48d7" />

## Fix in action

![FixerFunctionPatch](https://github.com/user-attachments/assets/9e5b2975-5dd5-4cc6-8057-75e38726520c)

