### PR TITLE
Only trigger CD when a version bump is detected in `package.json`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Log when unchanged
               if: steps.version_check.outputs.changed == 'false'
-              run: 'echo "No version change :/"'
+              run: 'echo "No version change :/ Skipping npm publish."'
 
     publish:
         name: Publish to NPM

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,18 +20,23 @@ jobs:
             pull-requests: read
 
         outputs:
-            version_bumped: ${{ steps.filter.outputs.version_bumped }}
+            version_bumped: ${{ steps.version_check.outputs.changed }}
 
         steps:
             - uses: actions/checkout@v4
 
-            - name: Check for changes in specific paths
-              id: filter
-              uses: dorny/paths-filter@v3.0.2
-              with:
-                  filters: |
-                      version_bumped:
-                      - 'package.json'
+            # https://github.com/marketplace/actions/version-check
+            - name: Check if version has been updated
+              id: version_check
+              uses: EndBug/version-check@v2
+
+            - name: Log when changed
+              if: steps.version_check.outputs.changed == 'true'
+              run: 'echo "Version change found in commit ${{ steps.version_check.outputs.commit }}! New version: ${{ steps.version_check.outputs.version }} (${{ steps.version_check.outputs.type }})"'
+
+            - name: Log when unchanged
+              if: steps.version_check.outputs.changed == 'false'
+              run: 'echo "No version change :/"'
 
     publish:
         name: Publish to NPM

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+packageManager=pnpm@10.11.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
This updates the CD workflow to only trigger "Publish to npm" job when a version change is detected vs any change in `package.json` and fixes #17 .

We're using `Endbug/version-check` github actions for this.
https://github.com/marketplace/actions/version-check