### PR TITLE
Refactor rule tester creation into a reusable utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {

--- a/tests/rule-tester.ts
+++ b/tests/rule-tester.ts
@@ -1,0 +1,24 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import parser from "@typescript-eslint/parser";
+
+// https://typescript-eslint.io/developers/custom-rules/#testing-typed-rules
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+export const getRuleTester = () => {
+    return new RuleTester({
+        languageOptions: {
+            parser,
+            parserOptions: {
+                projectService: {
+                    allowDefaultProject: ["*.ts*"],
+                },
+                tsconfigRootDir: __dirname,
+                ecmaVersion: 2024,
+            },
+        },
+    });
+};

--- a/tests/swallowed-error-context.test.ts
+++ b/tests/swallowed-error-context.test.ts
@@ -1,27 +1,7 @@
 import { noSwallowedErrorCause } from "../src/rules/no-swallowed-error-cause";
-import { RuleTester } from "@typescript-eslint/rule-tester";
-import parser from "@typescript-eslint/parser";
-import * as vitest from "vitest";
+import { getRuleTester } from "./rule-tester";
 
-// https://github.com/typescript-eslint/typescript-eslint/issues/7275#issuecomment-1643242066
-RuleTester.afterAll = vitest.afterAll;
-RuleTester.it = vitest.it;
-RuleTester.itOnly = vitest.it.only;
-RuleTester.describe = vitest.describe;
-
-// https://typescript-eslint.io/developers/custom-rules/#testing-typed-rules
-const ruleTester = new RuleTester({
-    languageOptions: {
-        parser,
-        parserOptions: {
-            projectService: {
-                allowDefaultProject: ["*.ts*"],
-            },
-            tsconfigRootDir: __dirname,
-            ecmaVersion: 2024,
-        },
-    },
-});
+const ruleTester = getRuleTester();
 
 ruleTester.run("no-swallowed-error-cause", noSwallowedErrorCause, {
     valid: [


### PR DESCRIPTION
This creates a reusable utility function to instantiate a `RuleTester` object with appropriate configuration.

The motivation behind this is to **avoid repeating the instantiation code** and configuration, if more rules are added in the future with accompanying test files.

This also helps maintaining consistency as it leads to single source of truth for the `RuleTester` configuration.
