### PR TITLE
Update license type to `MIT` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "plugin"
     ],
     "author": "Amnish Singh Arora",
-    "license": "ISC",
+    "license": "MIT",
     "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/node": "^22.15.3",


### PR DESCRIPTION
The `package.json` file was using the wrong license type (**ISC**), even though this project uses **MIT** from the time of creation.

I've updated the field to reflect the correct license type.

```json
"license": "MIT",
```