### PR TITLE
Include types in the published bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "test": "vitest --run",
-        "build": "tsc --build tsconfig.build.json",
+        "build": "tsc --build tsconfig.build.json && node scripts/cjs-fix.js",
         "lint": "pnpm run \"/^lint:.*/\"",
         "lint:docs": "markdownlint --config .markdownlintrc.json \"**/*.md\"",
         "lint:eslint-docs": "eslint-doc-generator --check",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "files": [
         "dist"
     ],
+    "types": "dist/index.d.ts",
     "repository": {
         "type": "git",
         "url": "https://github.com/Amnish04/eslint-plugin-error-cause"

--- a/scripts/cjs-fix.js
+++ b/scripts/cjs-fix.js
@@ -1,0 +1,24 @@
+/**
+ * This patch makes sure that the default export in the bundled output is CJS compatible like so:
+ *
+ * ```js
+ * module.exports = plugin.
+ * ```
+ *
+ * By default, the generated export from ESM typescript looks like:
+ *
+ * ```js
+ * exports.default = plugin;
+ * ```
+ *
+ * which is incompatible with tools like `eslint-doc-generator`;
+ *
+ * We can't directly use ESM style export in typescript source code as it can't be used to generate type declarations in final bundle.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const file = path.join(__dirname, '../dist/index.js');
+let content = fs.readFileSync(file, 'utf8');
+content = content.replace(/exports\.default\s*=\s*plugin;/, 'module.exports = plugin;');
+fs.writeFileSync(file, content);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,10 @@ const configs = {
     ],
 };
 
-type ErrorConfigPlugin = Omit<typeof plugin, "configs"> & {
+type ErrorCausePlugin = Omit<typeof plugin, "configs"> & {
     configs: typeof configs;
 };
 
 Object.assign(plugin.configs, configs);
 
-export default plugin as ErrorConfigPlugin;
+export default plugin as ErrorCausePlugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const plugin = {
     processors: {},
 };
 
-Object.assign(plugin.configs, {
+const configs = {
     recommended: [
         {
             plugins: {
@@ -21,6 +21,12 @@ Object.assign(plugin.configs, {
             },
         },
     ],
-});
+};
 
-module.exports = plugin;
+type ErrorConfigPlugin = Omit<typeof plugin, "configs"> & {
+    configs: typeof configs;
+};
+
+Object.assign(plugin.configs, configs);
+
+export default plugin as ErrorConfigPlugin;

--- a/src/rules/no-swallowed-error-cause.ts
+++ b/src/rules/no-swallowed-error-cause.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
-interface MyPluginDocs {
+export interface MyPluginDocs {
     recommended: boolean;
 }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,9 @@
     "compilerOptions": {
         "noEmit": false,
         "rootDir": "src",
-        "outDir": "dist"
+        "outDir": "dist",
+        "declaration": true,
+        "declarationMap": true
     },
     "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
 @dverbru filed #29 which helped me realize that I wasn't including types in the bundle published to npm.

In this PR, I have:

1. Started including a generated types declaration file for the plugin.
2. Fixed the exported plugin type by explicitly casting it to a custom type.

I can't fully test it locally, so will have to publish a test version to make sure it works.