### PR TITLE
Revise README for rule migration and archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-<h1 align="center">eslint-plugin-error-cause</h1>
+# Rule has migrated 🎉
 
-<div align="center">
-    <a href="https://www.npmjs.com/package/eslint-plugin-error-cause">
+This rule has been added to [`eslint`](https://github.com/eslint/eslint) project, and the docs can be found [here](https://eslint.org/docs/latest/rules/preserve-caught-error).
+This repo is no longer maintained and is archived.
+
+# eslint-plugin-error-cause
+
+<a href="https://www.npmjs.com/package/eslint-plugin-error-cause">
         <img src="https://img.shields.io/npm/v/eslint-plugin-error-cause?color=dark" alt="NPM Version">
     </a>
     <a href="https://github.com/Amnish04/eslint-plugin-error-cause/actions">
@@ -13,11 +17,8 @@
     <a href="https://github.com/Amnish04/eslint-plugin-error-cause/blob/main/LICENSE">
         <img src="https://img.shields.io/github/license/Amnish04/eslint-plugin-error-cause?color=red" alt="GitHub License">
     </a>
-</div>
 
-<p align="center">
-    An ESLint plugin with rules to report loss of original <a href="https://nodejs.org/api/errors.html#error_cause">error cause</a>, when re-throwing errors.
-</p>
+An ESLint plugin with rules to report loss of original <a href="https://nodejs.org/api/errors.html#error_cause">error cause</a>, when re-throwing errors.
 
 ![code-art](https://github.com/user-attachments/assets/d4a68b8d-897b-4df9-a605-f24850d5759d)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This rule has been added to [`eslint`](https://github.com/eslint/eslint) project, and the docs can be found [here](https://eslint.org/docs/latest/rules/preserve-caught-error).
 This repo is no longer maintained and is archived.
 
-# eslint-plugin-error-cause
+## eslint-plugin-error-cause
 
 <a href="https://www.npmjs.com/package/eslint-plugin-error-cause">
         <img src="https://img.shields.io/npm/v/eslint-plugin-error-cause?color=dark" alt="NPM Version">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rule has migrated 🎉
 
-This rule has been added to [`eslint`](https://github.com/eslint/eslint) project, and the docs can be found [here](https://eslint.org/docs/latest/rules/preserve-caught-error).
+This rule has been added to [`eslint`](https://github.com/eslint/eslint) project, and the docs can be [found here](https://eslint.org/docs/latest/rules/preserve-caught-error).
 This repo is no longer maintained and is archived.
 
 ## eslint-plugin-error-cause

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-error-cause",
-    "version": "1.2.9",
+    "version": "1.2.10",
     "description": "ESLint rules to detect swallowed error causes when rethrowing exceptions.",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
This rule has been integrated into [eslint](https://github.com/eslint/eslint) as one of the core rules.

https://github.com/eslint/eslint/pull/19913

Available in the latest ESLint release for `v9.35.0`:
https://github.com/eslint/eslint/releases/tag/v9.35.0

This repo will be archived and no longer maintained!

